### PR TITLE
Update roles.yaml

### DIFF
--- a/roles.yaml
+++ b/roles.yaml
@@ -22,7 +22,7 @@ Steering committee:
 
     Accountabilities:
     - The steering committee has to meet at least once every three months.
-    - The meeting minutes should be anomized and shared with the community.
+    - The meeting minutes should be anonymised and shared with the community.
 
 Core developers:
   role_holders:
@@ -207,3 +207,77 @@ Website admins:
     - Implementing design or structural improvements to meet the community's evolving needs.
     - Troubleshooting technical issues and liaising with hosting providers or developers as needed.
     - Promoting accessibility and ensuring compliance with web standards and best practices.
+
+Community Support Specialist:
+  role_holders:
+    - name: "Patrick Schmitt"
+      period: "2020-present"
+    - name: "Lilian Schuster"
+      period: "2020-present"
+    - name: "Fabien Maussion"
+      period: "2016–present"
+    - name: "Anouk Vlug"
+      period: "2021-present"
+    - name: "Lizz Ultee"
+      period: "2022-present"
+    - name: "Applications open"
+      period: "Get in touch!"
+  past_role_holders: 
+    - name: "Beatriz Recinos"
+      period: "2022-2024"
+    - name: "Jan Malles"
+      period: "2020–2023"
+    - name: "Julia Eis"
+      period: "2020–2022"
+    - name: "Matthias Dusch"
+      period: "2020-2021"
+  role_description: |
+    The purpose of the community support specialists is to ensure timely problem-solving for individuals by leveraging community support.
+
+    Community support specialists are responsible for:
+      - responding to community members' inquiries, 
+      - providing support, and
+      - facilitating connections between those who need help and those who can provide it.
+
+Outreach and Communication Volunteers:
+  role_holders:
+    - name: "Fabien Maussion"
+      period: "2016–present"
+    - name: "Lilian Schuster"
+      period: "2020–present"
+    - name: "Patrick Schmitt"
+      period: "2021–present"
+    - name: "Alexander Fischer"
+      period: "2024–present"
+    - name: "Applications open"
+      period: "Get in touch!"
+  past_role_holders:
+    - name: "Anouk Vlug"
+      period: "2020–2024"
+  role_description: |
+    The purpose of the outreach and communication volunteers is to expand the reach of OGGM by communicating the value of glacier science to the public and other stakeholders.
+
+    Outreach and communication volunteers are responsible for: 
+      - translating complex science into accessible content and engaging with the broader community
+      - managing social media channels and writing blog posts
+      
+GitHub Issue Triagist:
+  role_holders:
+      - name: "Fabien Maussion"
+        period: "2016–present"
+      - name: "Anouk Vlug"
+        period: "2021–present"
+      - name: "Patrick Schmitt"
+        period: "2022–present"
+      - name: "Timo Rothenpieler"
+        period: "2016-present"
+  past_role_holders:
+      - name: "Matthias Dusch"
+        period: "2019–2021"
+  role_description: |
+    The purpose of the GitHub Issue Triagists is to ensure no GitHub issues go uncommented, providing effective issue management and resolution.
+
+    GitHub Issue Triagists are responsible for: 
+      - monitoring GitHub issues,
+      - ensuring each issue is addressed,
+      - providing comments, and coordinating with developers for resolution.


### PR DESCRIPTION
filled out three additional roles with slack and github issue history (related to #9 )
- Community Support Specialist
- Outreach and Communication Volunteers
- GitHub Issue Triagist

I tried to use the same style in the descriptions, by using the draft text as in #9. Probably not complete. Names and years were roughly estimated, partly via checking some slack and github history. 
