### PR TITLE
Move myself from present to past role holder

### DIFF
--- a/roles.yaml
+++ b/roles.yaml
@@ -68,13 +68,13 @@ IT infrastructure managers:
 
 Documentation and tutorials developers:
   role_holders:
-    - name: "Anouk Vlug"
-      period: "2020-present"
     - name: "Lilian Schuster"
       period: "2020-present"
     - name: "Beatriz Recinos"
       period: "2016-present"
-  past_role_holders: []
+  past_role_holders: 
+    - name: "Anouk Vlug"
+      period: "2020-2024"
   role_description: |
     The purpose of the documentation and tutorials developers role is to make OGGM accessible
     to a broad audience by creating educational resources and maintaining user documentation


### PR DESCRIPTION
As I'm no longer actively contributing to the "Documentation and tutorials developers" role, I think it is time to move my name to the past role holder status. This PR contains that change.